### PR TITLE
fix(Language-Flag-Colors): correct the country codes of Japan and Bangladesh

### DIFF
--- a/.changeset/friendly-snakes-lick.md
+++ b/.changeset/friendly-snakes-lick.md
@@ -1,0 +1,5 @@
+---
+"language-flag-colors": minor
+---
+
+fix the country code (ISO 3166-1) of Japan and Bangladesh

--- a/packages/Language-Flag-Colors/src/languages.ts
+++ b/packages/Language-Flag-Colors/src/languages.ts
@@ -2050,7 +2050,7 @@ const languages: Language[] = [
 	},
 	{
 		country: "Japan",
-		countryCode: "ja",
+		countryCode: "jp",
 		direction: "ltr",
 		flag: {
 			emoji: "🇯🇵",
@@ -3768,7 +3768,7 @@ const languages: Language[] = [
 	},
 	{
 		country: "Japan",
-		countryCode: "ja",
+		countryCode: "jp",
 		direction: "ltr",
 		flag: {
 			emoji: "🇯🇵",

--- a/packages/Language-Flag-Colors/src/languages.ts
+++ b/packages/Language-Flag-Colors/src/languages.ts
@@ -767,7 +767,7 @@ const languages: Language[] = [
 	},
 	{
 		country: "Bangladesh",
-		countryCode: "bn",
+		countryCode: "bd",
 		direction: "ltr",
 		flag: {
 			emoji: "🇧🇩",


### PR DESCRIPTION
Hi @Bas950 I fixed the Japan country code as "jp".
https://www.iso.org/obp/ui/#iso:code:3166:JP

closes #61 

Thank you, have a nice day